### PR TITLE
feat: Add OverlayIdentifier API for duplicate overlay control

### DIFF
--- a/Sources/SimpleOverlaySystem/OverlayManager.swift
+++ b/Sources/SimpleOverlaySystem/OverlayManager.swift
@@ -146,8 +146,8 @@ extension OverlayManager {
   /// - Returns: A valid `OverlayID` to use, or `nil` if the overlay should be ignored.
   private func resolveIdentifier(_ identifier: OverlayIdentifier) -> OverlayID? {
     switch identifier.kind {
-    case .auto(let uuid):
-      return uuid
+    case .auto:
+      return OverlayID()
 
     case .named(let key, let action):
       if contains(key: key) {

--- a/Sources/SimpleOverlaySystem/OverlayTypes.swift
+++ b/Sources/SimpleOverlaySystem/OverlayTypes.swift
@@ -61,49 +61,34 @@ public enum DuplicateAction: Sendable {
 /// ```
 public struct OverlayIdentifier: Hashable, Sendable {
   enum Kind: Hashable, Sendable {
-    case auto(UUID)
+    case auto
     case named(String, DuplicateAction)
   }
 
   let kind: Kind
 
-  /// Creates an auto-generated unique identifier.
-  ///
-  /// Each call creates a new UUID, so multiple overlays with `.auto` identifiers
-  /// will always be treated as distinct.
-  public static var auto: Self { .init(kind: .auto(UUID())) }
+  /// Automatically generates a unique identifier for every presentation (default behavior).
+  public static var auto: Self { .init(kind: .auto) }
 
-  /// Creates a named identifier that ignores duplicate presentations.
+  /// Ignores the presentation if an overlay with the same key is already active.
   ///
-  /// If an overlay with the same key is already presented, the new presentation
-  /// request is ignored and the method returns `nil`.
-  ///
-  /// - Parameter name: A unique string key for the overlay.
+  /// - Parameter key: A unique string key for the overlay.
   /// - Returns: An identifier configured to ignore duplicates.
-  public static func unique(_ name: String) -> Self {
-    .init(kind: .named(name, .ignore))
+  public static func unique(_ key: String) -> Self {
+    .init(kind: .named(key, .ignore))
   }
 
-  /// Creates a named identifier that replaces existing overlays.
+  /// Replaces any existing overlay with the same key before presenting the new one.
   ///
-  /// If an overlay with the same key is already presented, it is dismissed
-  /// before the new overlay is presented.
-  ///
-  /// - Parameter name: A unique string key for the overlay.
+  /// - Parameter key: A unique string key for the overlay.
   /// - Returns: An identifier configured to replace duplicates.
-  public static func replacing(_ name: String) -> Self {
-    .init(kind: .named(name, .replace))
+  public static func replacing(_ key: String) -> Self {
+    .init(kind: .named(key, .replace))
   }
 
   /// Extracts the string key if this is a named identifier.
   var namedKey: String? {
     if case .named(let key, _) = kind { return key }
-    return nil
-  }
-
-  /// Extracts the duplicate action if this is a named identifier.
-  var duplicateAction: DuplicateAction? {
-    if case .named(_, let action) = kind { return action }
     return nil
   }
 }

--- a/Tests/SimpleOverlaySystemTests/SimpleOverlaySystemTests.swift
+++ b/Tests/SimpleOverlaySystemTests/SimpleOverlaySystemTests.swift
@@ -7,8 +7,8 @@ struct OverlayManagerTests {
   @Test("dismissTop removes only the last overlay")
   @MainActor func dismissTopRemovesLastOverlayOnly() {
     let manager = OverlayManager()
-    let firstID = manager.presentCentered { EmptyView() }
-    let secondID = manager.presentCentered { EmptyView() }
+    let firstID = manager.presentCentered { EmptyView() }!
+    let secondID = manager.presentCentered { EmptyView() }!
 
     #expect(manager.stack.count == 2)
     #expect(manager.top?.id == secondID)
@@ -35,9 +35,9 @@ struct OverlayManagerTests {
   @Test("dismiss(id:) removes a specific overlay")
   @MainActor func dismissByIdRemovesSpecificOverlay() {
     let manager = OverlayManager()
-    let firstID = manager.presentCentered { EmptyView() }
-    let secondID = manager.presentCentered { EmptyView() }
-    let thirdID = manager.presentCentered { EmptyView() }
+    let firstID = manager.presentCentered { EmptyView() }!
+    let secondID = manager.presentCentered { EmptyView() }!
+    let thirdID = manager.presentCentered { EmptyView() }!
 
     #expect(manager.stack.count == 3)
 
@@ -59,7 +59,7 @@ struct OverlayManagerTests {
         .onTapBackground {
           // Custom handler would be called instead of default dismiss
         }
-    }
+    }!
 
     guard let item = manager.item(withID: id) else {
       #expect(Bool(false), "Failed to present overlay")
@@ -67,7 +67,7 @@ struct OverlayManagerTests {
     }
 
     // Verify that the overlay has the tap policy
-    #expect(item.dismissPolicy == .tap)
+    #expect(item.dismissPolicy == DismissPolicy.tap)
 
     // Note: The actual handler registration via PreferenceKey cannot be tested
     // in a unit test without a view hierarchy. This requires UI testing.
@@ -115,5 +115,140 @@ struct ConvenienceAPITests {
 extension OverlayManager {
   fileprivate func item(withID id: OverlayID) -> OverlayItem? {
     stack.first(where: { $0.id == id })
+  }
+}
+
+@Suite("OverlayIdentifier API")
+struct OverlayIdentifierTests {
+  @Test("auto identifier allows multiple overlays")
+  @MainActor func autoIdentifierAllowsMultiple() {
+    let manager = OverlayManager()
+
+    let first = manager.presentCentered(id: .auto) { EmptyView() }
+    let second = manager.presentCentered(id: .auto) { EmptyView() }
+
+    #expect(first != nil)
+    #expect(second != nil)
+    #expect(first != second)
+    #expect(manager.stack.count == 2)
+  }
+
+  @Test("default parameter uses auto behavior")
+  @MainActor func defaultParameterIsAuto() {
+    let manager = OverlayManager()
+
+    let first = manager.presentCentered { EmptyView() }
+    let second = manager.presentCentered { EmptyView() }
+
+    #expect(first != nil)
+    #expect(second != nil)
+    #expect(manager.stack.count == 2)
+  }
+
+  @Test("unique identifier ignores duplicate presentation")
+  @MainActor func uniqueIdentifierIgnoresDuplicate() {
+    let manager = OverlayManager()
+
+    let first = manager.presentCentered(id: .unique("sheet")) { Text("First") }
+    let second = manager.presentCentered(id: .unique("sheet")) { Text("Second") }
+
+    #expect(first != nil)
+    #expect(second == nil, "Second presentation should be ignored")
+    #expect(manager.stack.count == 1)
+  }
+
+  @Test("unique identifier allows different keys")
+  @MainActor func uniqueIdentifierAllowsDifferentKeys() {
+    let manager = OverlayManager()
+
+    let first = manager.presentCentered(id: .unique("sheet-a")) { EmptyView() }
+    let second = manager.presentCentered(id: .unique("sheet-b")) { EmptyView() }
+
+    #expect(first != nil)
+    #expect(second != nil)
+    #expect(manager.stack.count == 2)
+  }
+
+  @Test("replacing identifier dismisses existing and presents new")
+  @MainActor func replacingIdentifierReplacesExisting() {
+    let manager = OverlayManager()
+
+    let first = manager.presentCentered(id: .replacing("alert")) { Text("First") }
+    let second = manager.presentCentered(id: .replacing("alert")) { Text("Second") }
+
+    #expect(first != nil)
+    #expect(second != nil)
+    #expect(first != second, "Should have different IDs")
+    #expect(manager.stack.count == 1, "Only one overlay should exist")
+    #expect(manager.top?.id == second)
+  }
+
+  @Test("contains(key:) returns true for existing key")
+  @MainActor func containsKeyReturnsTrue() {
+    let manager = OverlayManager()
+
+    manager.presentCentered(id: .unique("settings")) { EmptyView() }
+
+    #expect(manager.contains(key: "settings"))
+    #expect(!manager.contains(key: "nonexistent"))
+  }
+
+  @Test("contains(key:) returns false for auto identifiers")
+  @MainActor func containsKeyFalseForAuto() {
+    let manager = OverlayManager()
+
+    manager.presentCentered(id: .auto) { EmptyView() }
+
+    #expect(!manager.contains(key: "auto"))
+    #expect(!manager.contains(key: ""))
+  }
+
+  @Test("dismiss(key:) removes overlay with matching key")
+  @MainActor func dismissKeyRemovesMatching() {
+    let manager = OverlayManager()
+
+    manager.presentCentered(id: .unique("todo")) { EmptyView() }
+    manager.presentCentered(id: .unique("settings")) { EmptyView() }
+
+    #expect(manager.stack.count == 2)
+
+    manager.dismiss(key: "todo")
+
+    #expect(manager.stack.count == 1)
+    #expect(!manager.contains(key: "todo"))
+    #expect(manager.contains(key: "settings"))
+  }
+
+  @Test("presentAnchored supports identifier")
+  @MainActor func presentAnchoredSupportsIdentifier() {
+    let manager = OverlayManager()
+
+    let first = manager.presentAnchored(
+      id: .unique("tooltip"),
+      anchorFrame: CGRect(x: 0, y: 0, width: 100, height: 50),
+      placement: .bottom()
+    ) { EmptyView() }
+
+    let second = manager.presentAnchored(
+      id: .unique("tooltip"),
+      anchorFrame: CGRect(x: 0, y: 0, width: 100, height: 50),
+      placement: .bottom()
+    ) { EmptyView() }
+
+    #expect(first != nil)
+    #expect(second == nil)
+    #expect(manager.stack.count == 1)
+  }
+
+  @Test("mixed auto and unique identifiers coexist")
+  @MainActor func mixedIdentifiersCoexist() {
+    let manager = OverlayManager()
+
+    manager.presentCentered(id: .unique("sheet")) { EmptyView() }
+    manager.presentCentered(id: .auto) { EmptyView() }
+    manager.presentCentered(id: .auto) { EmptyView() }
+
+    #expect(manager.stack.count == 3)
+    #expect(manager.contains(key: "sheet"))
   }
 }


### PR DESCRIPTION
Merged via squash commit in 49fbda1. Closing manually.